### PR TITLE
Fix cxx17 mac os

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # cmake file for building LCIO
 # @author Frank Gaede, DESY
 # @author Jan Engels, DESY
-CMAKE_MINIMUM_REQUIRED( VERSION 3.0 FATAL_ERROR )
+CMAKE_MINIMUM_REQUIRED( VERSION 3.5 FATAL_ERROR )
 ########################################################
 
 

--- a/sio/src/SIO_stream.cc
+++ b/sio/src/SIO_stream.cc
@@ -325,8 +325,8 @@ printf(  "    -ASCII----------\n");
 // Scan down the buffer, printing a dump record every 16 bytes.
 //
 memset(  &outbuf[ 0], ' ', sizeof( outbuf ) );
-sprintf( &outbuf[ 1], "%8d",  offset );
-sprintf( &outbuf[10], "%p",  (void*) dmpbeg );
+snprintf( &outbuf[ 1], 9, "%8d",  offset );
+snprintf( &outbuf[10], 77-11, "%p",  (void*) dmpbeg );
 outbuf[ 9] = ':';
 outbuf[18] = ' ';
 outbuf[76] = '\0';
@@ -353,8 +353,8 @@ while( dmpbeg < dmpend )
         printf( "%s\n", outbuf );
 
         memset(  &outbuf[ 0], ' ', sizeof( outbuf ) );
-        sprintf( &outbuf[ 1], "%8d",  offset );
-        sprintf( &outbuf[10], "%p",  (void*) dmpbeg );
+        snprintf( &outbuf[ 1], 9, "%8d",  offset );
+        snprintf( &outbuf[10], 77-11, "%p",  (void*) dmpbeg );
         outbuf[ 9] = ':';
         outbuf[18] = ' ';
         outbuf[76] = '\0';

--- a/src/cpp/include/IMPL/ParticleIDImpl.h
+++ b/src/cpp/include/IMPL/ParticleIDImpl.h
@@ -11,7 +11,10 @@ namespace IMPL {
 
   /** Helper class to sort ParticleIDs wrt. their likelihood.
    */
-  class PIDSort : public std::binary_function<EVENT::ParticleID*,EVENT::ParticleID*,bool>{
+   // Was:
+   // class PIDSort : public std::binary_function<const EVENT::ParticleID*, const EVENT::ParticleID*, bool> {
+   //This is not needed extra verbiage that uses deprecated std::binary_function.
+  class PIDSort {
   public:
     bool operator()(const EVENT::ParticleID* p1, const EVENT::ParticleID* p2){
       return p1->getLikelihood() > p2->getLikelihood() ;

--- a/src/cpp/include/UTIL/lStdHep.hh
+++ b/src/cpp/include/UTIL/lStdHep.hh
@@ -125,7 +125,7 @@ public:
    static int         getMinor(void) { return(MINOR); };
    static const char *getText(void)  {
       static char buff[80];
-      sprintf(buff, "lStdHep version %d.%d (%02d.%02d.%d) by W.G.J. Langeveld, SLAC",
+      snprintf(buff, sizeof(buff), "lStdHep version %d.%d (%02d.%02d.%d) by W.G.J. Langeveld, SLAC",
               MAJOR, MINOR, DAY, MONTH, YEAR);
       return(buff);
    };

--- a/src/cpp/include/UTIL/lXDR.hh
+++ b/src/cpp/include/UTIL/lXDR.hh
@@ -37,7 +37,7 @@ public:
    static int         getMinor(void) { return(MINOR); };
    static const char *getText(void)  {
       static char buff[80];
-      sprintf(buff, "lXDR version %d.%d (%02d.%02d.%d) by W.G.J. Langeveld, SLAC",
+      snprintf(buff, sizeof(buff), "lXDR version %d.%d (%02d.%02d.%d) by W.G.J. Langeveld, SLAC",
               MAJOR, MINOR, DAY, MONTH, YEAR);
       return(buff);
    };

--- a/src/cpp/src/EXAMPLE/addRandomAccess.cc
+++ b/src/cpp/src/EXAMPLE/addRandomAccess.cc
@@ -58,24 +58,24 @@ int main(int argc, char** argv ){
 	  
 	  FILE* f = fopen( FILEN[i].c_str()  , "r+") ;
 	  
-	  if( f != 0 ){
+	  if( f != nullptr ){
 	    
 	    fseek( f ,  -( LCSIO_RANDOMACCESS_SIZE ) , SEEK_END ) ; 
-	    std::string bla("") ;
+	    std::string bla;
 	    bla.resize(17) ;
 	    
-	    int status = fread( &bla[0] , sizeof(char) , 16 , f ) ;
+	    fread( &bla[0] , sizeof(char) , 16 , f ) ;
 	    
 	    //	    std::cout << "  ====== read : [" << bla << "]" << std::endl ; 
 	    
 	    if( !strcmp( bla.c_str() , "LCIORandomAccess")  ){ 
 	      
 	      
-	      status = fseek( f ,  -(16) , SEEK_CUR ) ;
+	      fseek( f ,  -(16) , SEEK_CUR ) ;
 	      
 	      bla = "LCIORandomIGNORE" ;
 	      
-	      status = fwrite( &bla[0] , 1 , 16 , f ) ;
+	      fwrite( &bla[0] , 1 , 16 , f ) ;
 	      
 	      //	      std::cout << "  --------- wrote " << bla << " to file - bytes written " << status << std::endl; 
 	    } 

--- a/src/cpp/src/UTIL/Operators.cc
+++ b/src/cpp/src/UTIL/Operators.cc
@@ -2693,11 +2693,11 @@ namespace UTIL{
         }
         out << endl;
 	const TrackStateVec& trackStates=trk->getTrackStates(); 
-	for(int s=0; s<trackStates.size(); s++){
-	  out<<"track state location = "<<trackStates[s]->getLocation()
-	     <<"   ReferencePoint (x,y,z) tracking frame = ("<<trackStates[s]->getReferencePoint()[0]
-	     <<", "<<trackStates[s]->getReferencePoint()[1]
-	     <<", "<<trackStates[s]->getReferencePoint()[2]<<")";
+	for(auto trackState : trackStates){
+	  out<<"track state location = "<<trackState->getLocation()
+	     <<"   ReferencePoint (x,y,z) tracking frame = ("<<trackState->getReferencePoint()[0]
+	     <<", "<<trackState->getReferencePoint()[1]
+	     <<", "<<trackState->getReferencePoint()[2]<<")";
 	  out<<endl;
 	}
 


### PR DESCRIPTION

BEGINRELEASENOTES
- Minor code changes to allow compiling C++17 with clang compiler on MacOS Sequoia 
- - Most important change is getting rid of std::binary_function and sprintf. 
ENDRELEASENOTES

Tested on ifarm linux systems.